### PR TITLE
Fix chat toggle

### DIFF
--- a/angular-app/angular.json
+++ b/angular-app/angular.json
@@ -27,7 +27,14 @@
               "src/custom-theme.scss",
               "src/styles.css"
             ],
-            "scripts": []
+            "scripts": [],
+            "allowedCommonJsDependencies": [
+              "firebase/app",
+              "@firebase/app",
+              "@firebase/component",
+              "@firebase/firestore",
+              "@firebase/util"
+            ]
           },
           "configurations": {
             "production": {

--- a/angular-app/src/app/app.component.html
+++ b/angular-app/src/app/app.component.html
@@ -6,7 +6,7 @@
     <mat-sidenav-content>
       <router-outlet></router-outlet>
     </mat-sidenav-content>
-    <mat-sidenav #chat class="sidechat-container" mode="side" position="end" opened>
+    <mat-sidenav #chat class="sidechat-container" mode="side" position="end">
       <app-chat-drawer></app-chat-drawer>
     </mat-sidenav>
   </mat-sidenav-container>

--- a/angular-app/src/app/app.component.ts
+++ b/angular-app/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, ViewChild } from '@angular/core';
+import { Component, OnInit, AfterViewChecked, ViewChild } from '@angular/core';
 import { MatSidenav } from '@angular/material/sidenav';
 
 import { ToggleChatService } from './toggle-chat.service';
@@ -9,7 +9,7 @@ import { AuthService } from './auth.service';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent implements OnInit, AfterViewInit {
+export class AppComponent implements OnInit, AfterViewChecked {
 
   @ViewChild('chat') public chat: MatSidenav;
   public user$;
@@ -23,7 +23,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.user$ = this.authService.getUser();
   }
 
-  ngAfterViewInit(): void {
+  ngAfterViewChecked(): void {
     console.log("setting chat for toggle service");
     this.toggleChatService.setChat(this.chat);
   }


### PR DESCRIPTION
Ensures that the chat sidenav is actually set to allow toggling and suppresses some compile-time warnings about dependencies (they're part of Firebase so we can't really do anything about them)