### PR TITLE
Basic project access control

### DIFF
--- a/angular-app/firestore.rules
+++ b/angular-app/firestore.rules
@@ -1,7 +1,25 @@
+rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write;
+    function isSignedIn() {
+    	return request.auth.uid != null;
+    }
+    
+    match /projects/{projectID} {
+    	function isOwnedBy(userId) {
+    		return get(/databases/$(database)/documents/projects/$(projectID)).data.roles[userId] == "owner";
+    	}
+    	function hasCollaborator(userId) {
+    		return get(/databases/$(database)/documents/projects/$(projectID)).data.roles[userId] in ["owner", "editor"];
+    	}
+    
+    	allow create: if isSignedIn();
+    	allow read, update: if hasCollaborator(request.auth.uid);
+			allow delete: if isOwnedBy(request.auth.uid);
+      
+      match /files/{document=**} {
+      	allow read, write: if hasCollaborator(request.auth.uid);
+      }
     }
   }
 }

--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule, MAT_TABS_CONFIG } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -88,6 +89,7 @@ import { ProjectService } from './project.service';
     MatProgressSpinnerModule,
     MatSidenavModule,
     MatSnackBarModule,
+    MatTableModule,
     MatTabsModule,
     MatTooltipModule,
     MatToolbarModule,

--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { LeftMenuComponent } from './left-menu/left-menu.component';
 import { CreateProjectDialogComponent } from './create-project-dialog/create-project-dialog.component';
 import { ChatDrawerComponent } from './chat-drawer/chat-drawer.component';
 import { ConfirmationDialogComponent } from './confirmation-dialog/confirmation-dialog.component';
+import { ManageCollaboratorsComponent } from './manage-collaborators/manage-collaborators.component';
 import { ProjectDetailComponent } from './project-detail/project-detail.component';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 import { UserProfileComponent } from './user-profile/user-profile.component';
@@ -57,6 +58,7 @@ import { ProjectService } from './project.service';
     ChatDrawerComponent,
     CreateProjectDialogComponent,
     ConfirmationDialogComponent,
+    ManageCollaboratorsComponent,
     ProjectDetailComponent,
     UserProfileComponent,
     DiscoveryComponent,

--- a/angular-app/src/app/create-project-dialog/create-project-dialog.component.ts
+++ b/angular-app/src/app/create-project-dialog/create-project-dialog.component.ts
@@ -31,11 +31,10 @@ export class CreateProjectDialogComponent implements OnInit {
 
   createProject(): void {
     this.projectService.addProject({
-      owner: this.user.displayName,
+      owner: this.user.uid,
       title: this.title,
       collaborators: this.collaborators,
       tags: this.tags,
-      files: []
     });
 
     this.dialogRef.close();

--- a/angular-app/src/app/create-project-dialog/create-project-dialog.component.ts
+++ b/angular-app/src/app/create-project-dialog/create-project-dialog.component.ts
@@ -30,10 +30,15 @@ export class CreateProjectDialogComponent implements OnInit {
   }
 
   createProject(): void {
+    let roles = {};
+    roles[this.user.uid] = "owner";
+    for (let collaborator of this.collaborators) {
+      roles[collaborator] = "editor";
+    }
+
     this.projectService.addProject({
-      owner: this.user.uid,
       title: this.title,
-      collaborators: this.collaborators,
+      roles: roles,
       tags: this.tags,
     });
 

--- a/angular-app/src/app/manage-collaborators/manage-collaborators.component.css
+++ b/angular-app/src/app/manage-collaborators/manage-collaborators.component.css
@@ -1,0 +1,3 @@
+.mat-form-field {
+  margin-right: 10px;
+}

--- a/angular-app/src/app/manage-collaborators/manage-collaborators.component.css
+++ b/angular-app/src/app/manage-collaborators/manage-collaborators.component.css
@@ -1,3 +1,7 @@
 .mat-form-field {
   margin-right: 10px;
 }
+
+table {
+  width: 100%;
+}

--- a/angular-app/src/app/manage-collaborators/manage-collaborators.component.html
+++ b/angular-app/src/app/manage-collaborators/manage-collaborators.component.html
@@ -5,8 +5,19 @@
     <input matInput [(ngModel)]="collaboratorId">
   </mat-form-field>
   <button mat-flat-button color="primary" (click)="addCollaborator()">Add</button>
+  <table mat-table [dataSource] = "project.roles | keyvalue">
+    <ng-container matColumnDef="uid">
+      <th mat-header-cell *matHeaderCellDef>UID</th>
+      <td mat-cell *matCellDef="let collaborator">{{collaborator.key}}</td>
+    </ng-container>
+    <ng-container matColumnDef="role">
+      <th mat-header-cell *matHeaderCellDef>Role</th>
+      <td mat-cell *matCellDef="let collaborator">{{collaborator.value}}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="tableColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: tableColumns"></tr>
+  </table>
 </mat-dialog-content>
-
 <mat-dialog-actions>
   <button mat-flat-button (click)='closeDialog()'>Exit</button>
 </mat-dialog-actions>

--- a/angular-app/src/app/manage-collaborators/manage-collaborators.component.html
+++ b/angular-app/src/app/manage-collaborators/manage-collaborators.component.html
@@ -1,0 +1,12 @@
+<h2 mat-dialog-title>Manage Collaborators</h2>
+<mat-dialog-content>
+  <mat-form-field>
+    <mat-label>Collaborator user ID</mat-label>
+    <input matInput [(ngModel)]="collaboratorId">
+  </mat-form-field>
+  <button mat-flat-button color="primary" (click)="addCollaborator()">Add</button>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-flat-button (click)='closeDialog()'>Exit</button>
+</mat-dialog-actions>

--- a/angular-app/src/app/manage-collaborators/manage-collaborators.component.spec.ts
+++ b/angular-app/src/app/manage-collaborators/manage-collaborators.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ManageCollaboratorsComponent } from './manage-collaborators.component';
+
+describe('ManageCollaboratorsComponent', () => {
+  let component: ManageCollaboratorsComponent;
+  let fixture: ComponentFixture<ManageCollaboratorsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ManageCollaboratorsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ManageCollaboratorsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-app/src/app/manage-collaborators/manage-collaborators.component.ts
+++ b/angular-app/src/app/manage-collaborators/manage-collaborators.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 
 import { Project } from '../project';
@@ -11,15 +12,16 @@ import { ProjectService } from '../project.service';
   styleUrls: ['./manage-collaborators.component.css']
 })
 export class ManageCollaboratorsComponent implements OnInit {
-  public project: Project
+  public project: Project;
   public collaboratorId: string;
+  public tableColumns = ['uid', 'role'];
 
   constructor(
     private projectService: ProjectService,
     public dialogRef: MatDialogRef<ManageCollaboratorsComponent>,
     @Inject(MAT_DIALOG_DATA) public data,
   ) { 
-    this.project = data;
+    data.subscribe(project => this.project = project);
   }
 
   ngOnInit(): void {

--- a/angular-app/src/app/manage-collaborators/manage-collaborators.component.ts
+++ b/angular-app/src/app/manage-collaborators/manage-collaborators.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { first } from 'rxjs/operators';
+
+import { Project } from '../project';
+import { ProjectService } from '../project.service';
+
+@Component({
+  selector: 'app-manage-collaborators',
+  templateUrl: './manage-collaborators.component.html',
+  styleUrls: ['./manage-collaborators.component.css']
+})
+export class ManageCollaboratorsComponent implements OnInit {
+  public project: Project
+  public collaboratorId: string;
+
+  constructor(
+    private projectService: ProjectService,
+    public dialogRef: MatDialogRef<ManageCollaboratorsComponent>,
+    @Inject(MAT_DIALOG_DATA) public data,
+  ) { 
+    this.project = data;
+  }
+
+  ngOnInit(): void {
+  }
+
+  addCollaborator(): void {
+    if ((this.collaboratorId || '').trim()) {
+      this.projectService.updateProject(this.project, { [`roles.${this.collaboratorId}`]: "editor" });
+    }
+    this.collaboratorId = '';
+  }
+
+  closeDialog(): void {
+    this.dialogRef.close();
+  }
+}

--- a/angular-app/src/app/mock-projects.ts
+++ b/angular-app/src/app/mock-projects.ts
@@ -1,6 +1,4 @@
-import { Project } from './project';
-
-export const PROJECTS: Project[] = [
+export const PROJECTS = [
   
   { title: "Sonata 2020", owner: "Scarlatti", collaborators: ["Beethoven", "Mozart"], tags: ["classical"] },
   { title: "A Hard Place", owner: "Keffir", collaborators: ["Baz"], tags: ["rock"] },

--- a/angular-app/src/app/mock-projects.ts
+++ b/angular-app/src/app/mock-projects.ts
@@ -2,12 +2,12 @@ import { Project } from './project';
 
 export const PROJECTS: Project[] = [
   
-  { title: "Sonata 2020", owner: "Scarlatti", collaborators: ["Beethoven", "Mozart"], tags: ["classical"], files: [] },
-  { title: "A Hard Place", owner: "Keffir", collaborators: ["Baz"], tags: ["rock"], files: [] },
-  { title: "Jazz", owner: "Adam", collaborators: ["Blue", "Ronan"], tags: ["jazz", "background"], files: [] },
-  { title: "Cerulean", owner: "Anya", collaborators: ["kvitka"], tags: ["r&b", "chill"], files: [] },
-  { title: "Hip-Hop", owner: "BB", collaborators: ["Gunn"], tags: ["hip-hop"], files: [] },
-  { title: "Bubblegum", owner: "Haisha", collaborators: [], tags: ["pop", "happy"], files: [] },
-  { title: "This Nation", owner: "Yu", collaborators: ["Noh"], tags: ["country"], files: [] },
-  { title: "nitetime", owner: "zjx", collaborators: [], tags: ["edm", "dance"], files: [] },
+  { title: "Sonata 2020", owner: "Scarlatti", collaborators: ["Beethoven", "Mozart"], tags: ["classical"] },
+  { title: "A Hard Place", owner: "Keffir", collaborators: ["Baz"], tags: ["rock"] },
+  { title: "Jazz", owner: "Adam", collaborators: ["Blue", "Ronan"], tags: ["jazz", "background"] },
+  { title: "Cerulean", owner: "Anya", collaborators: ["kvitka"], tags: ["r&b", "chill"] },
+  { title: "Hip-Hop", owner: "BB", collaborators: ["Gunn"], tags: ["hip-hop"] },
+  { title: "Bubblegum", owner: "Haisha", collaborators: [], tags: ["pop", "happy"] },
+  { title: "This Nation", owner: "Yu", collaborators: ["Noh"], tags: ["country"] },
+  { title: "nitetime", owner: "zjx", collaborators: [], tags: ["edm", "dance"] },
 ];

--- a/angular-app/src/app/project-detail/project-detail.component.html
+++ b/angular-app/src/app/project-detail/project-detail.component.html
@@ -23,7 +23,7 @@
     <mat-tab label="Settings">
       <mat-list role="list of project settings">
         <mat-list-item>
-          <button mat-flat-button color="primary" (click)="manageCollaborators(project)">View/Edit Collaborators</button>
+          <button mat-flat-button color="primary" (click)="manageCollaborators()">View/Edit Collaborators</button>
         </mat-list-item>
         <mat-list-item>
           Tags:

--- a/angular-app/src/app/project-detail/project-detail.component.html
+++ b/angular-app/src/app/project-detail/project-detail.component.html
@@ -23,13 +23,7 @@
     <mat-tab label="Settings">
       <mat-list role="list of project settings">
         <mat-list-item>
-          Owner: {{project.owner}}
-        </mat-list-item>
-        <mat-list-item>
-          Collaborators:
-          <mat-chip-list aria-label="project collaborators">
-            <mat-chip *ngFor="let collaborator of project.collaborators">{{collaborator}}</mat-chip>
-          </mat-chip-list>
+          <button mat-flat-button color="primary">View/Edit Collaborators</button>
         </mat-list-item>
         <mat-list-item>
           Tags:
@@ -38,7 +32,7 @@
           </mat-chip-list>
         </mat-list-item>
         <mat-list-item>
-          <button mat-button color="dark-warn" (click)="deleteProject(project)">Delete Project</button>
+          <button mat-flat-button color="warn" (click)="deleteProject(project)">Delete Project</button>
         </mat-list-item>
       </mat-list>
     </mat-tab>

--- a/angular-app/src/app/project-detail/project-detail.component.html
+++ b/angular-app/src/app/project-detail/project-detail.component.html
@@ -23,7 +23,7 @@
     <mat-tab label="Settings">
       <mat-list role="list of project settings">
         <mat-list-item>
-          <button mat-flat-button color="primary">View/Edit Collaborators</button>
+          <button mat-flat-button color="primary" (click)="manageCollaborators(project)">View/Edit Collaborators</button>
         </mat-list-item>
         <mat-list-item>
           Tags:

--- a/angular-app/src/app/project-detail/project-detail.component.ts
+++ b/angular-app/src/app/project-detail/project-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 
@@ -7,6 +7,7 @@ import { Project } from '../project';
 import { ProjectFile } from '../project-file';
 import { ProjectService } from '../project.service';
 import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
+import { ManageCollaboratorsComponent } from '../manage-collaborators/manage-collaborators.component';
 
 @Component({
   selector: 'app-project-detail',
@@ -61,6 +62,13 @@ export class ProjectDetailComponent implements OnInit, OnChanges {
 
   deleteFile(project: Project, file: ProjectFile) {
     this.projectService.deleteFile(project, file);
+  }
+
+  manageCollaborators(project: Project): void {
+    this.dialog.open(ManageCollaboratorsComponent, { 
+      width: '400px',
+      data: project,
+    });
   }
 
   deleteProject(project: Project) {

--- a/angular-app/src/app/project-detail/project-detail.component.ts
+++ b/angular-app/src/app/project-detail/project-detail.component.ts
@@ -64,10 +64,10 @@ export class ProjectDetailComponent implements OnInit, OnChanges {
     this.projectService.deleteFile(project, file);
   }
 
-  manageCollaborators(project: Project): void {
+  manageCollaborators(): void {
     this.dialog.open(ManageCollaboratorsComponent, { 
       width: '400px',
-      data: project,
+      data: this.project$,
     });
   }
 

--- a/angular-app/src/app/project.service.ts
+++ b/angular-app/src/app/project.service.ts
@@ -69,6 +69,11 @@ export class ProjectService {
     .catch(error => console.error("Error adding document: ", error));
   }
 
+  public updateProject(project: Project, changes: object): void {
+    this.firestore.collection<Project>(COLLECTION_PROJECTS).doc(project.title).update(changes)
+    .catch(error => console.error("Error updating document: ", error));
+  }
+
   public deleteProject(project: Project) {
     this.firestore.collection(COLLECTION_PROJECTS).doc(project.title).delete()
       .then(() => console.log(`Successfully deleted project ${project.title}`))

--- a/angular-app/src/app/project.service.ts
+++ b/angular-app/src/app/project.service.ts
@@ -4,7 +4,6 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable, of, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { AngularFirestore } from '@angular/fire/firestore';
 
 import { environment } from '../environments/environment';
 import { Project } from './project';

--- a/angular-app/src/app/project.ts
+++ b/angular-app/src/app/project.ts
@@ -4,6 +4,7 @@
  */
 export interface Project {
   title: string;
-  roles: Map<string, string>;
+  // mapping of uids to permission roles
+  roles: object;
   tags: string[];
 }

--- a/angular-app/src/app/project.ts
+++ b/angular-app/src/app/project.ts
@@ -4,7 +4,6 @@
  */
 export interface Project {
   title: string;
-  owner: string;
-  collaborators: string[];
+  roles: Map<string, string>;
   tags: string[];
 }

--- a/angular-app/src/app/project.ts
+++ b/angular-app/src/app/project.ts
@@ -1,10 +1,10 @@
 /**
- * Represents a single project.
+ * Represents a single project. Owner and collaborators strings must be their UIDs (user ID) 
+ * as set with Firebase authentication
  */
 export interface Project {
   title: string;
   owner: string;
   collaborators: string[];
   tags: string[];
-  files: string[];
 }

--- a/angular-app/src/app/projects/projects.component.html
+++ b/angular-app/src/app/projects/projects.component.html
@@ -9,13 +9,6 @@
     <mat-card-content>
       <mat-list>
         <mat-list-item>
-
-          Collaborators:
-          <mat-chip-list aria-label="project collaborators">
-            <mat-chip *ngFor="let collaborator of project.collaborators">{{collaborator}}</mat-chip>
-          </mat-chip-list>
-        </mat-list-item>
-        <mat-list-item>
           Tags:
           <mat-chip-list aria-label="project tags">
             <mat-chip *ngFor="let tag of project.tags">{{tag}}</mat-chip>


### PR DESCRIPTION
 - Users can now only see projects they are affiliated with (either owner/creator or editor)
 - Collaborators can be added to projects using their FirebaseAuth user ID. Display names are currently NOT shown in the UI.
 - Project role permissions have been significantly restructured.

Closes #28 
Closes #63 