### PR TITLE
UX enhancements 2

### DIFF
--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -50,6 +50,7 @@ import { WorkspaceComponent } from './workspace/workspace.component';
 
 import { AuthService } from './auth.service';
 import { ProjectService } from './project.service';
+import { ManageTagsComponent } from './manage-tags/manage-tags.component';
 
 @NgModule({
   declarations: [
@@ -67,6 +68,7 @@ import { ProjectService } from './project.service';
     MainFeedComponent,
     PageNotFoundComponent,
     WorkspaceComponent,
+    ManageTagsComponent,
   ],
   imports: [
     BrowserModule,

--- a/angular-app/src/app/create-project-dialog/create-project-dialog.component.html
+++ b/angular-app/src/app/create-project-dialog/create-project-dialog.component.html
@@ -20,7 +20,8 @@
       </mat-chip>
       <input 
                   [matChipInputFor]="collaboratorList"
-                  (matChipInputTokenEnd)="addCollaborator($event)">
+                  (matChipInputTokenEnd)="addCollaborator($event.input)"
+                  (focusout)="addCollaborator($event.target)">
     </mat-chip-list>
   </mat-form-field>
   <br>
@@ -34,7 +35,8 @@
       </mat-chip>
       <input 
                   [matChipInputFor]="tagList"
-                  (matChipInputTokenEnd)="addTag($event)">
+                  (matChipInputTokenEnd)="addTag($event.input)"
+                  (focusout)="addTag($event.target)">
     </mat-chip-list>
   </mat-form-field>
 </mat-dialog-content>

--- a/angular-app/src/app/create-project-dialog/create-project-dialog.component.html
+++ b/angular-app/src/app/create-project-dialog/create-project-dialog.component.html
@@ -14,7 +14,7 @@
     <mat-label>Add Collaborators</mat-label>
     <mat-chip-list #collaboratorList>
       <mat-chip *ngFor="let collaborator of collaborators" 
-                    [removable]="true" (removed)="remove(collaborator)">
+                    [removable]="true" (removed)="removeCollaborator(collaborator)">
         {{collaborator}}
         <mat-icon matChipRemove>cancel</mat-icon>
       </mat-chip>
@@ -28,7 +28,7 @@
     <mat-label>Add Tags</mat-label>
     <mat-chip-list #tagList>
       <mat-chip *ngFor="let tag of tags" 
-                  [removable]="true" (removed)="remove(tag)">
+                  [removable]="true" (removed)="removeTag(tag)">
         {{tag}}
         <mat-icon matChipRemove>cancel</mat-icon>
       </mat-chip>

--- a/angular-app/src/app/create-project-dialog/create-project-dialog.component.ts
+++ b/angular-app/src/app/create-project-dialog/create-project-dialog.component.ts
@@ -50,31 +50,29 @@ export class CreateProjectDialogComponent implements OnInit {
     this.router.navigate(['/workspace', this.title]);
   }
 
-  addCollaborator(event: MatChipInputEvent): void {
-    this.add(this.collaborators, event);
+  addCollaborator(element): void {
+    this.add(this.collaborators, element);
   }
 
   removeCollaborator(collaborator: string): void {
     this.remove(this.collaborators, collaborator);
   }
 
-  addTag(event: MatChipInputEvent): void {
-    this.add(this.tags, event);
+  addTag(element): void {
+    this.add(this.tags, element);
   }
 
   removeTag(tag: string): void {
     this.remove(this.tags, tag);
   }
 
-  add(list: string[], event: MatChipInputEvent): void {
-    const input = event.input;
-    const value = event.value;
-
-    if ((value || '').trim()) {
-      list.push(value.trim());
+  add(list: string[], element): void {
+    let cleaned = (element.value || '').trim();
+    if (cleaned && list.findIndex(element => element === cleaned) === -1) {
+      list.push(cleaned);
     }
-    if (input) {
-      input.value = '';
+    if (element) {
+      element.value = '';
     }
   }
 

--- a/angular-app/src/app/manage-tags/manage-tags.component.html
+++ b/angular-app/src/app/manage-tags/manage-tags.component.html
@@ -1,14 +1,13 @@
 <h2 mat-dialog-title>Project Tags for {{project.title}}</h2>
 <mat-dialog-content>
-  <mat-form-field>
-    <mat-label>Add Tags</mat-label>
+  <mat-form-field hintLabel="Add tags here">
     <mat-chip-list #tagList>
       <mat-chip *ngFor="let tag of tags" 
                   [removable]="true" (removed)="removeTag(tag)">
         {{tag}}
         <mat-icon matChipRemove>cancel</mat-icon>
       </mat-chip>
-      <input 
+      <input
                   [matChipInputFor]="tagList"
                   (matChipInputTokenEnd)="addTag($event.input)"
                   (focusout)="addTag($event.target)">

--- a/angular-app/src/app/manage-tags/manage-tags.component.html
+++ b/angular-app/src/app/manage-tags/manage-tags.component.html
@@ -1,0 +1,21 @@
+<h2 mat-dialog-title>Project Tags for {{project.title}}</h2>
+<mat-dialog-content>
+  <mat-form-field>
+    <mat-label>Add Tags</mat-label>
+    <mat-chip-list #tagList>
+      <mat-chip *ngFor="let tag of tags" 
+                  [removable]="true" (removed)="removeTag(tag)">
+        {{tag}}
+        <mat-icon matChipRemove>cancel</mat-icon>
+      </mat-chip>
+      <input 
+                  [matChipInputFor]="tagList"
+                  (matChipInputTokenEnd)="addTag($event.input)"
+                  (focusout)="addTag($event.target)">
+    </mat-chip-list>
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-flat-button (click)='saveTags()' color="primary">Save</button>
+  <button mat-flat-button (click)='closeDialog()' color="primary">Close</button>
+</mat-dialog-actions>

--- a/angular-app/src/app/manage-tags/manage-tags.component.spec.ts
+++ b/angular-app/src/app/manage-tags/manage-tags.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ManageTagsComponent } from './manage-tags.component';
+
+describe('ManageTagsComponent', () => {
+  let component: ManageTagsComponent;
+  let fixture: ComponentFixture<ManageTagsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ManageTagsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ManageTagsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-app/src/app/manage-tags/manage-tags.component.ts
+++ b/angular-app/src/app/manage-tags/manage-tags.component.ts
@@ -1,0 +1,67 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MatChipInputEvent } from '@angular/material/chips';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { first } from 'rxjs/operators';
+
+import { ProjectService } from '../project.service';
+import { Project } from '../project';
+
+@Component({
+  selector: 'app-manage-tags',
+  templateUrl: './manage-tags.component.html',
+  styleUrls: ['./manage-tags.component.css']
+})
+export class ManageTagsComponent implements OnInit {
+
+  public project: Project;
+
+  public tags: string[] = [];
+  public lyricsFileName: string;
+
+  constructor(
+    private projectService: ProjectService,
+    public dialogRef: MatDialogRef<ManageTagsComponent>,
+    @Inject(MAT_DIALOG_DATA) public data,
+  ) { 
+    data.subscribe(project => {
+      this.project = project;
+      this.tags = project.tags;
+    });
+  }
+
+  ngOnInit(): void {
+  }
+
+  addTag(element): void {
+    this.add(this.tags, element);
+  }
+
+  removeTag(tag: string): void {
+    this.remove(this.tags, tag);
+  }
+
+  add(list: string[], element): void {
+    let cleaned = (element.value || '').trim();
+    if (cleaned && list.findIndex(element => element === cleaned) === -1) {
+      list.push(cleaned);
+    }
+    if (element) {
+      element.value = '';
+    }
+  }
+
+  remove(list: string[], item: string): void {
+    const index = list.indexOf(item);
+    if (index >= 0) {
+      list.splice(index, 1);
+    }
+  }
+
+  saveTags(): void {
+    this.projectService.updateProject(this.project, { ["tags"]: this.tags });
+  }
+
+  closeDialog(): void {
+    this.dialogRef.close();
+  }
+}

--- a/angular-app/src/app/project-detail/project-detail.component.css
+++ b/angular-app/src/app/project-detail/project-detail.component.css
@@ -1,3 +1,9 @@
 .mat-spinner {
   margin-left: 10px;
 }
+
+.settings .mat-list-item {
+  height: auto;
+  padding: 5px 0;
+}
+

--- a/angular-app/src/app/project-detail/project-detail.component.html
+++ b/angular-app/src/app/project-detail/project-detail.component.html
@@ -29,18 +29,17 @@
       </mat-selection-list>
     </mat-tab>
     <mat-tab label="Settings">
-      <mat-list role="list of project settings">
+      <mat-list class="settings" role="list of project settings">
         <mat-list-item>
           <button mat-flat-button color="primary" (click)="manageCollaborators()">View/Edit Collaborators</button>
         </mat-list-item>
         <mat-list-item>
-          Tags:
+          <button mat-flat-button color="primary" (click)="manageTags()">Manage Tags</button>
+        </mat-list-item>
+        <mat-list-item>
           <mat-chip-list aria-label="project tags">
             <mat-chip *ngFor="let tag of project.tags">{{tag}}</mat-chip>
           </mat-chip-list>
-        </mat-list-item>
-        <mat-list-item>
-          <button mat-flat-button color="primary" (click)="manageTags()">Manage Tags</button>
         </mat-list-item>
         <mat-list-item>
           <button mat-flat-button color="warn" (click)="deleteProject(project)">Delete Project</button>

--- a/angular-app/src/app/project-detail/project-detail.component.html
+++ b/angular-app/src/app/project-detail/project-detail.component.html
@@ -40,6 +40,9 @@
           </mat-chip-list>
         </mat-list-item>
         <mat-list-item>
+          <button mat-flat-button color="primary" (click)="manageTags()">Manage Tags</button>
+        </mat-list-item>
+        <mat-list-item>
           <button mat-flat-button color="warn" (click)="deleteProject(project)">Delete Project</button>
         </mat-list-item>
       </mat-list>

--- a/angular-app/src/app/project-detail/project-detail.component.ts
+++ b/angular-app/src/app/project-detail/project-detail.component.ts
@@ -8,6 +8,7 @@ import { ProjectFile } from '../project-file';
 import { ProjectService } from '../project.service';
 import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
 import { ManageCollaboratorsComponent } from '../manage-collaborators/manage-collaborators.component';
+import { ManageTagsComponent } from '../manage-tags/manage-tags.component';
 
 @Component({
   selector: 'app-project-detail',
@@ -63,6 +64,13 @@ export class ProjectDetailComponent implements OnInit, OnChanges {
 
   manageCollaborators(): void {
     this.dialog.open(ManageCollaboratorsComponent, { 
+      width: '400px',
+      data: this.project$,
+    });
+  }
+
+  manageTags(): void {
+    this.dialog.open(ManageTagsComponent, { 
       width: '400px',
       data: this.project$,
     });

--- a/angular-app/src/app/workspace/workspace.component.css
+++ b/angular-app/src/app/workspace/workspace.component.css
@@ -1,3 +1,7 @@
+.project-info-container {
+  max-width: 321px;
+}
+
 .adjustable {
     resize: vertical;
     overflow: auto;


### PR DESCRIPTION
More small things
- Closes #106 : tags & collaborators in CreateProjectDialog upon input losing focus
- Closes #102 : enable deleting tags, disallow duplicates
- Closes #33 : editing of both project tags and collaborators enabled after creation
- Closes #93 : Project tags editable
- workspace drawer width limited (formerly expanded with long file names/extra tags)